### PR TITLE
feat(header): add responsive mobile menu with slide-down drawer

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,20 +1,66 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   Box,
   Container,
   HStack,
+  VStack,
   Link as ChakraLink,
   Text,
   Flex,
   useColorModeValue,
+  IconButton,
+  Drawer,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerBody,
+  useDisclosure,
 } from '@chakra-ui/react';
 import { Link, useLocation } from 'react-router-dom';
 
+// Minimal hamburger icon - three lines
+const MenuIcon = () => (
+  <Box w="18px" h="14px" display="flex" flexDirection="column" justifyContent="space-between">
+    <Box h="2px" w="100%" bg="gray.700" borderRadius="full" />
+    <Box h="2px" w="100%" bg="gray.700" borderRadius="full" />
+    <Box h="2px" w="100%" bg="gray.700" borderRadius="full" />
+  </Box>
+);
+
+// Minimal close icon - X
+const CloseIcon = () => (
+  <Box w="18px" h="18px" position="relative">
+    <Box
+      h="2px"
+      w="100%"
+      bg="gray.700"
+      borderRadius="full"
+      position="absolute"
+      top="50%"
+      transform="rotate(45deg)"
+    />
+    <Box
+      h="2px"
+      w="100%"
+      bg="gray.700"
+      borderRadius="full"
+      position="absolute"
+      top="50%"
+      transform="rotate(-45deg)"
+    />
+  </Box>
+);
+
 const Header = () => {
   const location = useLocation();
+  const { isOpen, onOpen, onClose } = useDisclosure();
   const borderColor = useColorModeValue('gray.200', 'gray.700');
-  
-  const NavLink = ({ to, isExternal, children }) => {
+
+  // Close mobile menu on route change
+  useEffect(() => {
+    onClose();
+  }, [location.pathname, onClose]);
+
+  const NavLink = ({ to, isExternal, children, onClick }) => {
     const isActive = location.pathname === to || (to === '/blog' && location.pathname.startsWith('/blog'));
     
     return (
@@ -35,6 +81,37 @@ const Header = () => {
         }}
         target={isExternal ? '_blank' : undefined}
         rel={isExternal ? 'noreferrer' : undefined}
+        onClick={onClick}
+      >
+        {children}
+      </ChakraLink>
+    );
+  };
+
+  // Mobile nav link with larger touch target
+  const MobileNavLink = ({ to, children }) => {
+    const isActive = location.pathname === to || (to === '/blog' && location.pathname.startsWith('/blog'));
+
+    return (
+      <ChakraLink
+        as={Link}
+        to={to}
+        fontSize="lg"
+        fontWeight="500"
+        color={isActive ? 'brand.600' : 'gray.700'}
+        py={3}
+        w="100%"
+        display="block"
+        borderBottom="1px solid"
+        borderColor="gray.100"
+        _hover={{
+          color: 'brand.600',
+          bg: 'gray.50'
+        }}
+        _last={{
+          borderBottom: 'none'
+        }}
+        onClick={onClose}
       >
         {children}
       </ChakraLink>
@@ -69,7 +146,8 @@ const Header = () => {
             </Text>
           </Link>
           
-          <HStack spacing={8}>
+          {/* Desktop Navigation */}
+          <HStack spacing={8} display={{ base: 'none', md: 'flex' }}>
             <NavLink to="/blog">Writing</NavLink>
             <NavLink to="/projects">Projects</NavLink>
             <NavLink to="/research">Research</NavLink>
@@ -77,8 +155,44 @@ const Header = () => {
             <NavLink to="/bucketlist">Bucket List</NavLink>
             <NavLink to="/talk">Talk</NavLink>
           </HStack>
+
+          {/* Mobile Menu Button */}
+          <IconButton
+            display={{ base: 'flex', md: 'none' }}
+            aria-label={isOpen ? 'Close menu' : 'Open menu'}
+            variant="ghost"
+            size="sm"
+            icon={isOpen ? <CloseIcon /> : <MenuIcon />}
+            onClick={isOpen ? onClose : onOpen}
+            _hover={{ bg: 'gray.100' }}
+          />
         </Flex>
       </Container>
+
+      {/* Mobile Navigation Drawer */}
+      <Drawer
+        isOpen={isOpen}
+        placement="top"
+        onClose={onClose}
+      >
+        <DrawerOverlay bg="blackAlpha.300" backdropFilter="blur(4px)" />
+        <DrawerContent
+          mt="57px"
+          boxShadow="lg"
+          borderBottomRadius="md"
+        >
+          <DrawerBody py={2} px={4}>
+            <VStack align="stretch" spacing={0}>
+              <MobileNavLink to="/blog">Writing</MobileNavLink>
+              <MobileNavLink to="/projects">Projects</MobileNavLink>
+              <MobileNavLink to="/research">Research</MobileNavLink>
+              <MobileNavLink to="/recommendations">Reads</MobileNavLink>
+              <MobileNavLink to="/bucketlist">Bucket List</MobileNavLink>
+              <MobileNavLink to="/talk">Talk</MobileNavLink>
+            </VStack>
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
     </Box>
   );
 };


### PR DESCRIPTION
- Hide horizontal nav on mobile, show minimal hamburger icon
- Custom MenuIcon and CloseIcon components for minimalist aesthetic
- Drawer slides down from header with blurred overlay
- Mobile links have larger touch targets (py={3})
- Menu auto-closes on route navigation
- Maintains minimalist design while being functional on mobile