### PR TITLE
Add agent-native business goal to List 100

### DIFF
--- a/src/static/bucketList.json
+++ b/src/static/bucketList.json
@@ -62,6 +62,7 @@
         {"goal": "Drive through the night", "checked": false},
         {"goal": "Trek for a week deep in the Himalayas", "checked": false},
         {"goal": "Trek the apostles", "checked": false},
-        {"goal": "Eat at a Michelin star restaurant", "checked": true}
+        {"goal": "Eat at a Michelin star restaurant", "checked": true},
+        {"goal": "Start a 1-person agent-native business", "checked": false}
     ]
 }


### PR DESCRIPTION
Adds a new goal to List 100 (the life list / bucket list): "Start a 1-person agent-native business" (unchecked).

Single-line addition to `src/static/bucketList.json` — JSON validated, now 64 items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)