### PR TITLE
Add 3 goals to List 100 (founder, home, eclipse)

### DIFF
--- a/src/static/bucketList.json
+++ b/src/static/bucketList.json
@@ -65,6 +65,7 @@
         {"goal": "Eat at a Michelin star restaurant", "checked": true},
         {"goal": "Start a 1-person agent-native business", "checked": false},
         {"goal": "Back a founder", "checked": false},
-        {"goal": "Build a home", "checked": false}
+        {"goal": "Build a home", "checked": false},
+        {"goal": "See a total solar eclipse", "checked": true}
     ]
 }

--- a/src/static/bucketList.json
+++ b/src/static/bucketList.json
@@ -63,6 +63,8 @@
         {"goal": "Trek for a week deep in the Himalayas", "checked": false},
         {"goal": "Trek the apostles", "checked": false},
         {"goal": "Eat at a Michelin star restaurant", "checked": true},
-        {"goal": "Start a 1-person agent-native business", "checked": false}
+        {"goal": "Start a 1-person agent-native business", "checked": false},
+        {"goal": "Back a founder", "checked": false},
+        {"goal": "Build a home", "checked": false}
     ]
 }


### PR DESCRIPTION
Adds three goals to List 100 (`src/static/bucketList.json`):
- Back a founder
- Build a home
- See a total solar eclipse (marked done ✓)

JSON validated — 67 items total. (Rebased onto master; supersedes #10.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)